### PR TITLE
[qwen3-vl] Promote v009 prompt stack and add bda_eval review artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.0.0
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-packages
 
       - name: Run tests
         run: uv run pytest -v --cov=bda_svc --cov-report=term-missing

--- a/bda_eval/README.md
+++ b/bda_eval/README.md
@@ -24,11 +24,32 @@
 ## Output Folder Structure
 ```
 ├── path/to/results
-│   └── evaluation.csv        # CSV file with evaluation results
-│   └── reports_reference/    # Copy of reference report folder
-│   └── reports_predicted/    # Copy of predicted report folder
-│   └── images/bbox/both/     # Contains images with ref/pred bounding boxes
-│   └── logs_llmaaj/          # LLMaaJ score results
-│       ├── llmaaj.jsonl      # JSON Lines file (each line is a JSON object)
-│       ├── llmaaj.log        # Human-readable JSON format
+│   └── evaluation_<timestamp>.csv  # CSV file with evaluation results
+│   └── <reference-folder>/         # Copy of reference report folder
+│   └── <predicted-folder>/         # Copy of predicted report folder
+│   └── images_bbox_both/           # Combined ref+pred overlays
+│   └── images_bbox_reference/      # Reference-only overlays
+│   └── images_bbox_predicted/      # Predicted-only overlays
+│   └── images_crop_reference/      # Reference-driven crops
+│   └── images_crop_predicted/      # Predicted-driven crops
+│   └── images_bbox_review/         # Per-image side-by-side review sheets
+│   └── bbox_review_sheet.jpg       # Root review sheet when exactly one image is evaluated
+│   └── logs_llmaaj/                # LLMaaJ score results
+│       ├── llmaaj.jsonl            # JSON Lines file (each line is a JSON object)
+│       ├── llmaaj.log              # Human-readable JSON format
 ```
+
+## Prompt-Lab Review Note
+
+When `bda_eval` is run on exactly one shared image and an image folder is
+provided, it now emits a root-level `bbox_review_sheet.jpg` in addition to the
+other bbox artifacts. This is intended to support prompt-lab style visual
+comparison without relying on the older temporary `bda-svc` debug-export path.
+
+## Practical Notes
+
+- If `OLLAMA_API_KEY` is not set, `bda_eval` now skips LLMaaJ logic scoring and
+  still completes bbox artifact generation and CSV export.
+- If a compared report folder already lives inside the selected output
+  directory, `bda_eval` skips copying that folder onto itself instead of
+  failing.

--- a/bda_eval/bboxes.py
+++ b/bda_eval/bboxes.py
@@ -1,109 +1,307 @@
-"""Draw BDA bounding boxes from two sets of reports."""
+"""Draw BDA bounding boxes and review artifacts from two sets of reports."""
+
+from pathlib import Path
 
 import config
 import models
 from PIL import Image, ImageDraw, ImageFont
 
+FONT_PATH = Path(__file__).resolve().parent / "fonts" / "DejaVuSans.ttf"
+
+
+def _load_font(size: int) -> ImageFont.FreeTypeFont:
+    """Load the bundled TrueType font."""
+    return ImageFont.truetype(str(FONT_PATH), size)
+
+
+def _valid_targets(report: models.BDAReport) -> list[models.BDATarget]:
+    """Return targets with non-zero bounding boxes."""
+    return [
+        target
+        for target in report.targets
+        if (target.box.xmin, target.box.ymin, target.box.xmax, target.box.ymax)
+        != (0, 0, 0, 0)
+    ]
+
+
+def _image_path(img_filename: str) -> Path | None:
+    """Return the source image path if available."""
+    if config.IMAGES_DIR is None:
+        print("[*] Image folder not initialized. Skipping bbox artifacts.")
+        return None
+
+    img_path = config.IMAGES_DIR / img_filename
+    if not img_path.exists():
+        print(f"[*] Image `{img_path}` not found. Skipping bbox artifacts.")
+        return None
+
+    return img_path
+
+
+def _output_folder(folder_name: str) -> Path:
+    """Create and return an output folder under the eval output root."""
+    assert config.OUTPUT_DIR is not None, "[*] Output folder not initialized."
+    output_folder = config.OUTPUT_DIR / folder_name
+    output_folder.mkdir(parents=True, exist_ok=True)
+    return output_folder
+
 
 def draw_bbox(
     draw_obj: ImageDraw.ImageDraw,
-    obj_label: str,
     obj_bbox: models.BoundingBox,
     rect_color: str,
     label_text: str,
     font: ImageFont.FreeTypeFont,
-):
+) -> None:
     """Draw a single bounding box rectangle and corresponding label.
 
     Args:
         draw_obj: ImageDraw object
-        obj_label: The label assigned to the object within the report
         obj_bbox: BoundingBox object
         rect_color: Desired color of the bounding box rectangle
         label_text: Desired label text for the rectangle
         font: TTF font object
     """
-    # Create rectangle bounding box [(xmin, ymin), (xmax, ymax)]
     bbox_rect = [
         (obj_bbox.xmin, obj_bbox.ymin),
         (obj_bbox.xmax, obj_bbox.ymax),
     ]
 
-    # Check if object was not actually found within image (as per report)
     if bbox_rect == [(0, 0), (0, 0)]:
         return
 
-    label_fill = "white"
-    bbox_width = 3
+    if label_text:
+        left, top, right, bottom = draw_obj.textbbox(
+            (obj_bbox.xmin, obj_bbox.ymin), label_text, font=font
+        )
+        bbox_label_rect = [left, top, right, bottom + 5]
+        draw_obj.rectangle(bbox_label_rect, fill="white")
+        draw_obj.text((left, top), label_text, fill="black", font=font)
 
-    # Create label bounding box [(xmin, ymin), (xmax, ymax)]
-    left, top, right, bottom = draw_obj.textbbox(
-        (obj_bbox.xmin, obj_bbox.ymin), label_text, font=font
+    draw_obj.rectangle(bbox_rect, outline=rect_color, width=3)
+
+
+def _draw_report_overlay(
+    base_img: Image.Image,
+    report: models.BDAReport,
+    rect_color: str,
+    label_text: str,
+) -> Image.Image:
+    """Return a copy of an image with one report's boxes drawn on it."""
+    overlay = base_img.copy()
+    draw_obj = ImageDraw.Draw(overlay)
+    font = _load_font(18)
+
+    for target in report.targets:
+        draw_bbox(
+            draw_obj=draw_obj,
+            obj_bbox=target.box,
+            rect_color=rect_color,
+            label_text=label_text,
+            font=font,
+        )
+
+    return overlay
+
+
+def _combined_bbox(report: models.BDAReport) -> models.BoundingBox | None:
+    """Return the union bbox for all valid targets in a report."""
+    targets = _valid_targets(report)
+    if not targets:
+        return None
+
+    xmin = min(target.box.xmin for target in targets)
+    ymin = min(target.box.ymin for target in targets)
+    xmax = max(target.box.xmax for target in targets)
+    ymax = max(target.box.ymax for target in targets)
+    return models.BoundingBox(xmin=xmin, ymin=ymin, xmax=xmax, ymax=ymax)
+
+
+def _crop_box(
+    bbox: models.BoundingBox,
+    img_width: int,
+    img_height: int,
+) -> tuple[int, int, int, int]:
+    """Expand a bbox using the configured crop buffer ratio and clamp to image."""
+    width = max(1, bbox.xmax - bbox.xmin)
+    height = max(1, bbox.ymax - bbox.ymin)
+    pad_x = int(round(width * config.CROP_BUFFER_RATIO))
+    pad_y = int(round(height * config.CROP_BUFFER_RATIO))
+
+    xmin = max(0, bbox.xmin - pad_x)
+    ymin = max(0, bbox.ymin - pad_y)
+    xmax = min(img_width, bbox.xmax + pad_x)
+    ymax = min(img_height, bbox.ymax + pad_y)
+    return xmin, ymin, xmax, ymax
+
+
+def _placeholder_panel(size: tuple[int, int], message: str) -> Image.Image:
+    """Create a small placeholder panel when a crop cannot be made."""
+    panel = Image.new("RGB", size, color="white")
+    draw_obj = ImageDraw.Draw(panel)
+    draw_obj.rectangle(
+        [(0, 0), (size[0] - 1, size[1] - 1)],
+        outline="#999999",
+        width=2,
     )
+    font = _load_font(16)
+    left, top, right, bottom = draw_obj.textbbox((0, 0), message, font=font)
+    x = max(8, (size[0] - (right - left)) // 2)
+    y = max(8, (size[1] - (bottom - top)) // 2)
+    draw_obj.text((x, y), message, fill="#444444", font=font)
+    return panel
 
-    bbox_label_rect = [left, top, right, bottom + 5]
 
-    # Draw the label background rectangle
-    draw_obj.rectangle(bbox_label_rect, fill=label_fill)
+def _build_report_crop(
+    base_img: Image.Image,
+    report: models.BDAReport,
+) -> Image.Image:
+    """Build a crop from the union of valid report boxes."""
+    bbox = _combined_bbox(report)
+    if bbox is None:
+        return _placeholder_panel((160, 90), "No valid bbox")
 
-    # Draw the label
-    draw_obj.text((left, top), label_text, fill="black", font=font)
+    crop_rect = _crop_box(bbox, *base_img.size)
+    return base_img.crop(crop_rect)
 
-    # Draw the rectangle bounding box
-    draw_obj.rectangle(bbox_rect, outline=rect_color, width=bbox_width)
+
+def _save_image(
+    image: Image.Image,
+    folder_name: str,
+    prefix: str,
+    img_filename: str,
+) -> Path:
+    """Save an image under the eval output tree."""
+    output_folder = _output_folder(folder_name)
+    output_path = output_folder / f"{prefix}_{img_filename}"
+    image.save(output_path)
+    return output_path
+
+
+def _thumbnail_copy(image: Image.Image, max_size: tuple[int, int]) -> Image.Image:
+    """Return a copy of an image shrunk to fit within max_size."""
+    thumb = image.copy()
+    thumb.thumbnail(max_size)
+    return thumb
+
+
+def _sheet_titles() -> tuple[str, str]:
+    """Return user-facing labels for reference and predicted panels."""
+    reference = config.REFERENCE_LABEL or (
+        config.REFERENCE_DIR.name if config.REFERENCE_DIR else "Reference"
+    )
+    predicted = config.PREDICTED_LABEL or (
+        config.PREDICTED_DIR.name if config.PREDICTED_DIR else "Predicted"
+    )
+    return reference, predicted
+
+
+def _save_review_sheet(
+    img_filename: str,
+    ref_overlay: Image.Image,
+    pred_overlay: Image.Image,
+    ref_crop: Image.Image,
+    pred_crop: Image.Image,
+    write_root_sheet: bool,
+) -> None:
+    """Save a side-by-side review sheet for prompt-lab style visual review."""
+    ref_label, pred_label = _sheet_titles()
+    title_font = _load_font(16)
+    padding = 12
+    title_height = 24
+
+    left_width = max(ref_overlay.width, pred_overlay.width)
+    right_max = (left_width, max(ref_overlay.height, pred_overlay.height))
+    ref_crop_panel = _thumbnail_copy(ref_crop, right_max)
+    pred_crop_panel = _thumbnail_copy(pred_crop, right_max)
+    right_width = max(ref_crop_panel.width, pred_crop_panel.width)
+
+    row1_height = title_height + max(ref_overlay.height, ref_crop_panel.height)
+    row2_height = title_height + max(pred_overlay.height, pred_crop_panel.height)
+    sheet_width = padding * 3 + left_width + right_width
+    sheet_height = padding * 3 + row1_height + row2_height
+
+    sheet = Image.new("RGB", (sheet_width, sheet_height), color="white")
+    draw_obj = ImageDraw.Draw(sheet)
+
+    positions = [
+        (
+            f"{ref_label} Overlay",
+            ref_overlay,
+            padding,
+            padding,
+        ),
+        (
+            f"{ref_label} Crop",
+            ref_crop_panel,
+            padding * 2 + left_width,
+            padding,
+        ),
+        (
+            f"{pred_label} Overlay",
+            pred_overlay,
+            padding,
+            padding * 2 + row1_height,
+        ),
+        (
+            f"{pred_label} Crop",
+            pred_crop_panel,
+            padding * 2 + left_width,
+            padding * 2 + row1_height,
+        ),
+    ]
+
+    for title, image, x, y in positions:
+        draw_obj.text((x, y), title, fill="black", font=title_font)
+        sheet.paste(image, (x, y + title_height))
+
+    review_folder = _output_folder("images_bbox_review")
+    review_path = review_folder / f"bbox_review_{Path(img_filename).stem}.jpg"
+    sheet.save(review_path)
+
+    if write_root_sheet:
+        assert config.OUTPUT_DIR is not None, "[*] Output folder not initialized."
+        sheet.save(config.OUTPUT_DIR / "bbox_review_sheet.jpg")
 
 
 def draw_bboxes(
     img_filename: str,
     R_report: models.BDAReport,
     P_report: models.BDAReport,
-):
-    """Draw bounding boxes for all objects from both sets of reports.
+    write_root_review_sheet: bool = False,
+) -> None:
+    """Draw bbox artifacts for both reports and save a review sheet.
 
     Args:
         img_filename: Image filename (as set in BDA report)
         R_report: Reference BDAReport
         P_report: Predicted BDAReport
+        write_root_review_sheet: Save `bbox_review_sheet.jpg` in output root.
     """
-    # Load TrueType font
-    font = ImageFont.truetype("./fonts/DejaVuSans.ttf", 18)
-
-    # Create a draw object `draw_obj`
-    img_filename = R_report.metadata.image_filename
-    assert config.IMAGES_DIR is not None, "[*] Image folder not initialized."
-    img_path = config.IMAGES_DIR / img_filename
-
-    if not img_path.exists():
-        print(f"[*] Image `{img_path}` not found. Skipping.")
+    img_path = _image_path(R_report.metadata.image_filename)
+    if img_path is None:
         return
 
-    img = Image.open(img_path)
-    draw_obj = ImageDraw.Draw(img)
+    with Image.open(img_path) as image:
+        base_img = image.convert("RGB")
 
-    # Draw a bounding box for every reference target
-    for r_target in R_report.targets:
-        draw_bbox(
-            draw_obj=draw_obj,
-            obj_label=r_target.target_label,
-            obj_bbox=r_target.box,
-            rect_color="green",
-            label_text="human",
-            font=font,
-        )
+    combined = _draw_report_overlay(base_img, R_report, "green", "human")
+    combined = _draw_report_overlay(combined, P_report, "red", "model")
+    ref_overlay = _draw_report_overlay(base_img, R_report, "green", "")
+    pred_overlay = _draw_report_overlay(base_img, P_report, "red", "")
+    ref_crop = _build_report_crop(base_img, R_report)
+    pred_crop = _build_report_crop(base_img, P_report)
 
-    # Draw a bounding box for every predicted target
-    for p_target in P_report.targets:
-        draw_bbox(
-            draw_obj=draw_obj,
-            obj_label=p_target.target_label,
-            obj_bbox=p_target.box,
-            rect_color="red",
-            label_text="model",
-            font=font,
-        )
-
-    assert config.OUTPUT_DIR is not None, "[*] Output folder not initialized."
-    output_folder = config.OUTPUT_DIR / "images_bbox_both"
-    output_folder.mkdir(parents=True, exist_ok=True)
-
-    img.save(f"{output_folder}/bbox_{img_filename}")
+    _save_image(combined, "images_bbox_both", "bbox", img_filename)
+    _save_image(ref_overlay, "images_bbox_reference", "bbox", img_filename)
+    _save_image(pred_overlay, "images_bbox_predicted", "bbox", img_filename)
+    _save_image(ref_crop, "images_crop_reference", "crop", img_filename)
+    _save_image(pred_crop, "images_crop_predicted", "crop", img_filename)
+    _save_review_sheet(
+        img_filename=img_filename,
+        ref_overlay=ref_overlay,
+        pred_overlay=pred_overlay,
+        ref_crop=ref_crop,
+        pred_crop=pred_crop,
+        write_root_sheet=write_root_review_sheet,
+    )

--- a/bda_eval/config.py
+++ b/bda_eval/config.py
@@ -6,3 +6,6 @@ IMAGES_DIR: Path | None = None
 REFERENCE_DIR: Path | None = None
 PREDICTED_DIR: Path | None = None
 OUTPUT_DIR: Path | None = None
+REFERENCE_LABEL: str | None = None
+PREDICTED_LABEL: str | None = None
+CROP_BUFFER_RATIO: float = 0.2

--- a/bda_eval/main.py
+++ b/bda_eval/main.py
@@ -44,12 +44,14 @@ def main():
     config.OUTPUT_DIR = Path(args.output)
     config.OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Verify image folder exists
-    config.IMAGES_DIR = Path(args.images)
+    # Verify image folder exists when bbox artifacts are requested
+    config.IMAGES_DIR = Path(args.images) if args.images else None
 
     # Discover reports
     config.REFERENCE_DIR = Path(args.reference)
     config.PREDICTED_DIR = Path(args.predicted)
+    config.REFERENCE_LABEL = config.REFERENCE_DIR.name
+    config.PREDICTED_LABEL = config.PREDICTED_DIR.name
     R_multi_images, P_multi_images = discovery.get_reports(
         config.REFERENCE_DIR, config.PREDICTED_DIR
     )
@@ -67,6 +69,8 @@ def main():
         print(f"[*] Missing References: {missing_ref}")
 
     packages = []
+
+    write_root_review_sheet = len(common_keys) == 1
 
     # NOTE: "key" == image filename
     for key in common_keys:
@@ -91,13 +95,23 @@ def main():
             packages.extend(package)
 
         # Generate reference and model bounding boxes for current image
-        bboxes.draw_bboxes(img_filename=key, R_report=R_report, P_report=P_report)
+        if config.IMAGES_DIR is not None:
+            bboxes.draw_bboxes(
+                img_filename=key,
+                R_report=R_report,
+                P_report=P_report,
+                write_root_review_sheet=write_root_review_sheet,
+            )
 
     # Copy report folders into our destination output folder
     output_path_ref = config.OUTPUT_DIR / config.REFERENCE_DIR.name
     output_path_pred = config.OUTPUT_DIR / config.PREDICTED_DIR.name
-    shutil.copytree(config.REFERENCE_DIR, output_path_ref, dirs_exist_ok=True)
-    shutil.copytree(config.PREDICTED_DIR, output_path_pred, dirs_exist_ok=True)
+
+    if config.REFERENCE_DIR.resolve() != output_path_ref.resolve():
+        shutil.copytree(config.REFERENCE_DIR, output_path_ref, dirs_exist_ok=True)
+
+    if config.PREDICTED_DIR.resolve() != output_path_pred.resolve():
+        shutil.copytree(config.PREDICTED_DIR, output_path_pred, dirs_exist_ok=True)
 
     # Try to create the CSV and save to file
     result = export.save_csv(packages)

--- a/bda_eval/models.py
+++ b/bda_eval/models.py
@@ -492,16 +492,23 @@ Output ONLY valid JSON.
 
         return score_assess * (w_assess + (score_logic * w_logic))
 
-    def _evaluate_logic(self, R, matches: list[BDAMatch]):
+    def _evaluate_logic(self, R, matches: list[BDAMatch]) -> bool:
         """Evaluates BDAMatch logic concurrently (updating in-place).
 
         Args:
             R: The BDAReport containing human assessments.
             matches: List of BDAMatch objects.
         """
+        if not matches:
+            return False
+
         api_key = environ.get("OLLAMA_API_KEY")
         if not api_key:
-            raise KeyError("[*] Environment variable 'OLLAMA_API_KEY' not set.")
+            print(
+                "[*] Skipping LLMaaJ logic evaluation because "
+                "'OLLAMA_API_KEY' is not set."
+            )
+            return False
 
         timeout_secs = 60 * 15
 
@@ -542,6 +549,8 @@ Output ONLY valid JSON.
                         self._log_llmaaj(R, match, score, evaluation)
                 except Exception as e:
                     print(f"[*] LLMaaJ operation generated an exception: {e}")
+
+        return True
 
     def get_bda_matches(
         self,
@@ -684,8 +693,9 @@ Output ONLY valid JSON.
         # Query LLMaaJ for every matched pair (that's not OBJECT_NOT_FOUND)
         matches_valid = [match for match in matches if match.score_assess > 0.0]
 
-        print("\n[*] Submitting matches to LLMaaJ:\n")
-        self._evaluate_logic(R, matches_valid)
+        if matches_valid:
+            print("\n[*] Submitting matches to LLMaaJ:\n")
+            self._evaluate_logic(R, matches_valid)
 
         # Finish populating the `score` value for every match
         for match in matches:

--- a/bda_eval/tests/test_bboxes.py
+++ b/bda_eval/tests/test_bboxes.py
@@ -1,0 +1,79 @@
+"""Tests for bbox artifact generation."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import bboxes
+import config
+import models
+from PIL import Image
+
+
+def _target(
+    label: str,
+    xmin: int,
+    ymin: int,
+    xmax: int,
+    ymax: int,
+) -> models.BDATarget:
+    """Create a minimal target for bbox tests."""
+    return models.BDATarget(
+        target_label=label,
+        target_type=models.TargetType.MILITARY_EQUIPMENT,
+        damage_category=models.DamageMilitaryEquipment.DESTROYED,
+        confidence=models.Confidence.PROBABLE,
+        logic="test",
+        box=models.BoundingBox(xmin=xmin, ymin=ymin, xmax=xmax, ymax=ymax),
+        ndarray=[],
+    )
+
+
+def _report(image_filename: str, target: models.BDATarget) -> models.BDAReport:
+    """Create a minimal BDA report for bbox tests."""
+    metadata = models.BDAReportMetadata(
+        model_name="test-model",
+        image_id="test-image-id",
+        image_filename=image_filename,
+        date_created="2026-04-15T00:00:00Z",
+        report_type="PDA",
+        analyst="pytest",
+        inference_time="1.23",
+    )
+    return models.BDAReport(metadata=metadata, targets=[target])
+
+
+def test_draw_bboxes_emits_review_artifacts(tmp_path: Path) -> None:
+    """draw_bboxes should emit overlays, crops, and review sheets."""
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+    img_path = image_dir / "tank.jpg"
+    Image.new("RGB", (256, 122), color="white").save(img_path)
+
+    output_dir = tmp_path / "results"
+    config.IMAGES_DIR = image_dir
+    config.OUTPUT_DIR = output_dir
+    config.REFERENCE_DIR = Path("baseline")
+    config.PREDICTED_DIR = Path("candidate")
+    config.REFERENCE_LABEL = "Baseline"
+    config.PREDICTED_LABEL = "Candidate"
+    config.CROP_BUFFER_RATIO = 0.2
+
+    reference = _report("tank.jpg", _target("target_0", 51, 37, 128, 73))
+    predicted = _report("tank.jpg", _target("target_0", 46, 46, 128, 92))
+
+    bboxes.draw_bboxes(
+        img_filename="tank.jpg",
+        R_report=reference,
+        P_report=predicted,
+        write_root_review_sheet=True,
+    )
+
+    assert (output_dir / "images_bbox_both" / "bbox_tank.jpg").exists()
+    assert (output_dir / "images_bbox_reference" / "bbox_tank.jpg").exists()
+    assert (output_dir / "images_bbox_predicted" / "bbox_tank.jpg").exists()
+    assert (output_dir / "images_crop_reference" / "crop_tank.jpg").exists()
+    assert (output_dir / "images_crop_predicted" / "crop_tank.jpg").exists()
+    assert (output_dir / "images_bbox_review" / "bbox_review_tank.jpg").exists()
+    assert (output_dir / "bbox_review_sheet.jpg").exists()

--- a/bda_eval/tests/test_models.py
+++ b/bda_eval/tests/test_models.py
@@ -1,0 +1,66 @@
+"""Tests for BDA matching behavior."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import models
+import numpy as np
+
+
+def _target(
+    label: str,
+    xmin: int,
+    ymin: int,
+    xmax: int,
+    ymax: int,
+) -> models.BDATarget:
+    """Create a minimal target for matching tests."""
+    return models.BDATarget(
+        target_label=label,
+        target_type=models.TargetType.MILITARY_EQUIPMENT,
+        damage_category=models.DamageMilitaryEquipment.DESTROYED,
+        confidence=models.Confidence.PROBABLE,
+        logic="test",
+        box=models.BoundingBox(xmin=xmin, ymin=ymin, xmax=xmax, ymax=ymax),
+        ndarray=np.array(
+            [
+                models.TargetType.MILITARY_EQUIPMENT,
+                models.DamageMilitaryEquipment.DESTROYED,
+                models.Confidence.PROBABLE,
+            ]
+        ),
+    )
+
+
+def _report(image_filename: str, target: models.BDATarget) -> models.BDAReport:
+    """Create a minimal BDA report for matching tests."""
+    metadata = models.BDAReportMetadata(
+        model_name="test-model",
+        image_id="test-image-id",
+        image_filename=image_filename,
+        date_created="2026-04-15T00:00:00Z",
+        report_type="PDA",
+        analyst="pytest",
+        inference_time="1.23",
+    )
+    return models.BDAReport(metadata=metadata, targets=[target])
+
+
+def test_get_bda_matches_skips_logic_without_api_key(monkeypatch) -> None:
+    """Matching should still succeed when LLMaaJ credentials are unavailable."""
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+    reference = _report("tank.jpg", _target("target_0", 51, 37, 102, 73))
+    predicted = _report("tank.jpg", _target("target_0", 51, 37, 102, 73))
+
+    result = predicted.get_bda_matches(reference)
+
+    assert result is not None
+    matches, false_negatives, false_positives = result
+    assert len(matches) == 1
+    assert matches[0].score_logic == 0
+    assert matches[0].score == matches[0].score_assess * matches[0].w_assess
+    assert false_negatives == []
+    assert false_positives == []

--- a/src/bda_svc/pipeline/config.yaml
+++ b/src/bda_svc/pipeline/config.yaml
@@ -41,9 +41,35 @@ prompts:
     - First identify all valid targets using the target-type specific detection guidance below.
     - Then produce exactly one bounding box per valid target.
     - The number of detections must match the number of targets identified.
+    - If multiple valid targets are visibly distinct, output multiple detections. Do not merge neighboring targets into one box.
 
     TARGET-TYPE SPECIFIC DETECTION GUIDANCE
     {detection_guidance}
+
+    BOXING RULE
+    - Box the visible connected man-made body or structure of each target only.
+    - Use fire, smoke, muzzle flash, or debris only to help locate the target, not to define the box boundary.
+    - If smoke, flame, or dust hides part of a target, keep the box on the visible connected target body that remains.
+    - If two targets are visibly separate, even with nearby debris or overlap in the scene, return separate boxes.
+    - For buildings, return separate boxes for visibly separate buildings or clearly separate damaged structures. Do not merge neighboring structures into one box unless they are visibly one continuous target body.
+    - For buildings, only detect visible exterior building structures or clearly collapsed exterior structural remains.
+    - Do not treat indoor rooms, office interiors, cubicles, partitions, furniture, interior walls, ceiling tiles, or ordinary room contents as doctrinal building targets.
+    - If the image is primarily an indoor scene and no visible exterior building structure or collapsed structural remains are present, do not detect a building target.
+    - On intact or operational targets, box the visible target body only when the doctrinal target itself is clearly visible. Do not widen the detection prior from scene context alone.
+    - Do not box the smoke plume, flame column, muzzle flash, debris field between targets, rail bed, road, shadow, or empty ground.
+
+    CONTRASTIVE EXAMPLES
+    - Correct: a burning vehicle with smoke to the right -> box the visible connected vehicle body only.
+    - Correct: a firing vehicle with muzzle flash -> box the vehicle body only, not the flash or smoke.
+    - Correct: two neighboring damaged buildings with separate visible masses -> return separate boxes.
+    - Correct: collapsed exterior structural remains of two buildings -> return separate boxes if the structures are distinct.
+    - Incorrect: merge adjacent targets because smoke or debris overlaps them in the scene.
+    - Incorrect: treat an office interior, cubicle wall, or room partition as a building target.
+    - Incorrect: box the smoke plume, flash, empty terrain, or only the smallest local burn patch.
+
+    OUTPUT DISCIPLINE
+    - Return only the doctrinal target_type category.
+    - Do not infer a finer subtype such as locomotive, train car, truck, or artillery piece.
 
     BOUNDING BOX FORMAT
     - Format: {bbox_format}
@@ -84,13 +110,43 @@ prompts:
     - Focus only on the selected target object.
     - Do not reference crops, prompts, or analysis steps in the output.
     - Set logic to short factual observations only, using concise phrases separated by semicolons. Include only specific visible, doctrinally grounded evidence.
+    - In `brief_supporting_logic`, refer to the object only as the target, target body, or equipment. Do not infer a subtype such as locomotive, rail car, truck, or artillery piece from the surrounding scene.
+    - In `brief_supporting_logic`, do not use kill-mechanism or kill-state labels such as K-kill, mission kill, mobility kill, firepower kill, catastrophic kill, or similar shorthand. Describe only visible evidence.
+    - Do not state or imply K-kill, mission kill, unrepairable loss, or complete loss unless that outcome is directly and unambiguously visible.
+    - Fire and smoke are strong evidence of severe damage only when they are visibly affecting the target body itself.
+    - Do not treat muzzle flash, weapon discharge smoke, gun blast dust, exhaust, or normal firing obscuration as target damage by themselves.
+    - If visible flash or smoke appears to originate from the weapon muzzle or active firing event rather than from the target body, do not use that alone to justify `DAMAGED` or `DESTROYED`.
+    - Do not downgrade a target to `DAMAGED` only because some major components are still visible. If sustained fire and dense smoke are catastrophically affecting the target body, and the visible evidence suggests total loss is more likely than repairable damage, prefer `DESTROYED`.
+
+    OPERATIONAL FIRING GUIDANCE
+    - A target that appears actively firing or operating can still be `NO DAMAGE` if the visible target body remains intact and there are no visible signs of structural harm.
+    - Visible signs of structural harm include burning on the target body, blast damage on the body, holes, breaks, collapse, missing major components, severe deformation, or detached wreckage associated with the target.
+    - If the target body appears intact and the only dramatic visual effects are muzzle flash or discharge smoke, prefer `NO DAMAGE`.
+    - Use `DAMAGED` only when visible evidence on the target body itself shows actual damage, not just firing effects.
+
+    DECISION EXAMPLES
+    - If the target body is engulfed in sustained fire and dense smoke, and the visible evidence strongly suggests catastrophic loss but some structural detail is still obscured, prefer:
+      `damage_category = DESTROYED`
+      `confidence_level = PROBABLE`
+      `brief_supporting_logic = sustained fire; dense smoke; target body catastrophically affected but partly obscured`
+    - If the target appears actively firing, the flash and smoke are concentrated at the weapon muzzle, and the target body otherwise appears intact with no visible structural harm, prefer:
+      `damage_category = NO DAMAGE`
+      `confidence_level = CONFIRMED`
+      `brief_supporting_logic = active firing signature at muzzle; target body intact; no visible structural damage`
+    - If the target body is clearly wrecked with detached components and severe deformation, prefer factual wording such as:
+      `brief_supporting_logic = major components missing or detached; severe deformation visible; target body catastrophically damaged`
+
+    CATEGORY RECOVERY NOTE
+    - Visible remaining structure does not automatically imply `DAMAGED`.
+    - When the visible target body is heavily involved in sustained fire and dense smoke, use `DAMAGED` only if the evidence still looks more consistent with serious but potentially repairable damage than with catastrophic loss.
+    - When visible smoke is consistent with firing activity rather than body damage, do not escalate above `NO DAMAGE` without separate visible structural evidence.
 
     CONFIDENCE GUIDANCE
     Avoid overconfidence. High confidence should be used sparingly and only when visual evidence is clear and unmistakable.
     Incorrect high-confidence assessments are penalized more heavily than low-confidence ones.
     Always select the lowest confidence level consistent with the visible evidence.
-    - confirmed — clear, direct, unambiguous visual evidence with no reasonable alternative interpretation.
-    - probable — visible indicators suggesting the damage category, but evidence is incomplete, partially obscured, or ambiguous.
+    - confirmed — clear, direct, unambiguous visual evidence with no reasonable alternative interpretation. Use this only when the visible target body itself clearly supports the chosen category, including intact active-operation cases with no visible damage.
+    - probable — visible indicators strongly suggest the damage category, but evidence is incomplete, partly obscured by fire/smoke, or still leaves a reasonable alternative interpretation.
     - possible — weak, limited, or uncertain indicators; damage category cannot be determined definitively.
 
     OUTPUT
@@ -114,12 +170,23 @@ prompts:
     PRIOR TARGET ASSESSMENTS
     {target_assessments}
 
+    SUMMARY RULES
+    - Do not add a target subtype or platform identity beyond what appears in the prior assessments.
+    - Do not infer terrain or infrastructure details such as road, rail, track, runway, or bridge unless they are unmistakably visible.
+    - If the surrounding surface is unclear, use generic wording such as open terrain, ground surface, or outdoor scene.
+    - Keep the functional-impact sentence conservative and aligned with the prior target assessments.
+    - Do not claim complete loss, total mission failure, or broader operational effects unless that level of impact is directly supported by the prior assessments.
+
     SUMMARY GOAL
     Write a short (1-3 sentences) scene-level report in plain text.
     The report should:
     - first enumerate the targets from the prior assessments with their counts and conditions
-    - then summarize the overall scene as a whole based on the full-scene image
-    - then briefly describe the likely functional impact, if supported by the prior target assessments
+    - then summarize the overall scene as a whole based on the full-scene image using only broad, visible context
+    - then briefly describe the likely functional impact in conservative terms, if supported by the prior target assessments
+
+    SUMMARY EXAMPLE
+    - Good: One target assessed: 1 military_equipment, condition DESTROYED with PROBABLE confidence. The scene shows a burning target in open terrain with dense black smoke. The likely functional impact is severe degradation or loss of capability for the assessed target.
+    - Bad: A locomotive on a railway track is completely destroyed, causing total loss of logistics in the area.
 
     OUTPUT
     Return plain text only. No new lines.


### PR DESCRIPTION
## What changed

This branch contributes two linked updates:

1. Adds prompt-lab visual review artifacts to `bda_eval`
   - overlay outputs for reference and predicted bboxes
   - crop outputs for reference and predicted targets
   - per-image review sheets
   - root `bbox_review_sheet.jpg` support for prompt-lab comparisons
   - tests covering the new review-artifact behavior

2. Promotes the active working Qwen prompt stack for this model line into
   `src/bda_svc/pipeline/config.yaml`
   - `detect_objects` from `v006`
   - `assess_damage` from `v008`
   - `summarize_scene` from `v004`

## Why it changed

The goal was to move from isolated prompt-lab experimentation toward a tracked,
reviewable working config for this Qwen model line.

The prompt stack was built and validated incrementally, then unified as `v009`
after:

- focused confirmation on representative cases
- extra hard-case comparisons
- a broader 10-image baseline-vs-`v009` blind-style sweep

The `bda_eval` changes were added so prompt-grounding review can rely on
tracked evaluation functionality rather than temporary local-only debug export
helpers.

The resulting `v009` stack is not just the best local winner note anymore. It
is now the active working config for this model line going forward, with the
prompt-lab evidence trail preserved separately under local `z_reference_docs`.

## Validation used

Tracked checks:

- `uv run pytest bda_eval/tests`
- `uv run pytest tests/unit/test_yamls.py bda_eval/tests`

GitHub Actions CI for this PR validates branch health:

- unit and integration test execution
- Docker build and runnable pipeline behavior
- CI/runtime compatibility for the tracked branch state

It does **not** currently assert exact parity with the prompt-lab `v009`
winner outputs. The prompt-behavior evidence for this PR comes from the
prompt-lab validation runs recorded under local `z_reference_docs`, which are
kept outside normal branch history on purpose.

Prompt-lab validation highlights:

- direct `v009` focused confirmation on:
  - `tank_pressure`
  - `operational_tank4`
  - `destroyed_building4`
- additional baseline-vs-`v009` challenge comparison on 3 new images
- broader 10-image baseline-vs-`v009` blind sweep

Blind-sweep headline:

- `10 / 10` preserved target-count recall
- `6 / 10` preserved the same damage/confidence structure
- only `2 / 10` changed damage category at all

## Strongest claim

This is not just a tank-specific prompt mockup.

The strongest evidence is:

- preserved cross-image recall
- cleaner negative-scene behavior
- better multi-target separation
- improved cross-image stability across buildings, tanks, and trucks

## Known caveats

Two blind-sweep watch cases remain visible and should stay part of review:

- `destroyed_building5`
  - likely a real `v009` building-severity overcall
- `destroyed_tank37`
  - `v009` gives the cleaner bbox
  - `DAMAGED` is arguable under smoke/angle obscuration
  - but the current supporting logic is still too catastrophic for a clean
    `DAMAGED` read

These are category-calibration watch cases, not recall failures.

## Commit structure

- `566892a` — `Add prompt-lab review artifacts to bda_eval`
- `127051a` — `Promote v009 prompt stack into pipeline config`
- `ebeae30` — `Install workspace packages in CI`
