### PR TITLE
Fix/unicode

### DIFF
--- a/bda_eval/discovery.py
+++ b/bda_eval/discovery.py
@@ -90,10 +90,7 @@ def get_report(report_path: Path) -> tuple[str, dict] | None:
     return (match_value, json_obj)
 
 
-def get_reports(
-    ref_folder: Path | str,
-    pred_folder: Path | str
-) -> tuple[dict, dict]:
+def get_reports(ref_folder: Path | str, pred_folder: Path | str) -> tuple[dict, dict]:
     """Locate and parse BDA report files.
 
     Args:

--- a/bda_eval/main.py
+++ b/bda_eval/main.py
@@ -91,11 +91,7 @@ def main():
             packages.extend(package)
 
         # Generate reference and model bounding boxes for current image
-        bboxes.draw_bboxes(
-            img_filename=key,
-            R_report=R_report,
-            P_report=P_report
-        )
+        bboxes.draw_bboxes(img_filename=key, R_report=R_report, P_report=P_report)
 
     # Copy report folders into our destination output folder
     output_path_ref = config.OUTPUT_DIR / config.REFERENCE_DIR.name

--- a/src/bda_svc/export.py
+++ b/src/bda_svc/export.py
@@ -65,7 +65,7 @@ def save_json(
     json_path = output_path / f"{image_path.stem}_{timestamp}.json"
 
     with json_path.open("w", encoding="utf-8") as f:
-        json.dump(report, f, indent=4)
+        json.dump(report, f, indent=4, ensure_ascii=False)
 
     print(f"[*] Exported: {json_path}")
 

--- a/src/bda_svc/pipeline/config.yaml
+++ b/src/bda_svc/pipeline/config.yaml
@@ -40,7 +40,6 @@ prompts:
     RULES
     - First identify all valid targets using the target-type specific detection guidance below.
     - Then produce exactly one bounding box per valid target.
-    - Do not product a bounding box of all zeroes if target_type is not "object_not_found".
     - The number of detections must match the number of targets identified.
 
     TARGET-TYPE SPECIFIC DETECTION GUIDANCE
@@ -53,6 +52,7 @@ prompts:
     OUTPUT
     Return valid JSON only.
     Return a JSON object with a top-level detections field.
+    If no valid targets are visible, return {"detections": []}.
 
     OUTPUT SCHEMA
     {


### PR DESCRIPTION
I noticed the bda reports sometimes had raw unicode e.g. "\u2019" instead of an apostrophe. The minor change to export.py should fix this.

I also edited the detect_objects prompt because the model never actually sees "object_not_found" -- this is the fallback for when there are no objects or when there is an error parsing. I added the line "If no valid targets are visible, return {"detections": []}." because I'm guessing this is why we saw better results with the new prompt, but it might need some experimentation.